### PR TITLE
Adds a fast path option for ref tracking

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,19 @@
 			"label": "Run All Tests"
 		},
 		{
+			"type": "shell",
+			"command": "bin/temp-fast-test",
+			"windows": {
+				"command": ".\\bin\\temp-fast-test.cmd"
+			},
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": "build",
+			"label": "dm: find hard deletes"
+		},
+		{
 			"command": "${command:dreammaker.reparse}",
 			"group": "build",
 			"label": "dm: reparse"

--- a/bin/temp-fast-test.cmd
+++ b/bin/temp-fast-test.cmd
@@ -1,0 +1,4 @@
+@echo off
+:: Nuke this task once the Del the World unit test passes. This exists to fix those errors easily.
+
+call "%~dp0\..\tools\build\build.bat" --wait-on-error dm-test -DREFERENCE_TRACKING_FAST %*

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -42,6 +42,11 @@
 #define GC_FAILURE_HARD_LOOKUP
 #endif // REFERENCE_DOING_IT_LIVE
 
+#ifdef REFERENCE_TRACKING_FAST
+#define REFERENCE_TRACKING
+#define REFERENCE_TRACKING_DEBUG
+#endif
+
 //#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 #ifndef PRELOAD_RSC				//set to:

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -25,9 +25,10 @@
 	log_reftracker("Beginning search for references to a [type].")
 
 	var/starting_time = world.time
+	var/found_ref = FALSE
 
 	//Time to search the whole game for our ref
-	DoSearchVar(GLOB, "GLOB", search_time = starting_time) //globals
+	found_ref = DoSearchVar(GLOB, "GLOB", search_time = starting_time) || found_ref //globals
 	log_reftracker("Finished searching globals")
 
 	//Yes we do actually need to do this. The searcher refuses to read weird lists
@@ -36,25 +37,33 @@
 	for(var/key in global.vars)
 		global_vars[key] = global.vars[key]
 
-	DoSearchVar(global_vars, "Native Global", search_time = starting_time)
+	found_ref = DoSearchVar(global_vars, "Native Global", search_time = starting_time) || found_ref
 	log_reftracker("Finished searching native globals")
 
-	for(var/datum/thing in world) //atoms (don't beleive its lies)
-		DoSearchVar(thing, "World -> [thing.type]", search_time = starting_time)
-	log_reftracker("Finished searching atoms")
-
 	for(var/datum/thing) //datums
-		DoSearchVar(thing, "Datums -> [thing.type]", search_time = starting_time)
+		found_ref = DoSearchVar(thing, "Datums -> [thing.type]", search_time = starting_time) || found_ref
 	log_reftracker("Finished searching datums")
 
 	//Warning, attempting to search clients like this will cause crashes if done on live. Watch yourself
 #ifndef REFERENCE_DOING_IT_LIVE
 	for(var/client/thing) //clients
-		DoSearchVar(thing, "Clients -> [thing.type]", search_time = starting_time)
+		found_ref = DoSearchVar(thing, "Clients -> [thing.type]", search_time = starting_time) || found_ref
 	log_reftracker("Finished searching clients")
 #endif
 
-	log_reftracker("Completed search for references to a [type].")
+#ifdef REFERENCE_TRACKING_FAST
+	if(found_ref)
+		log_reftracker("Skipped searching atoms (other ref(s) found)")
+	else
+		for(var/datum/thing in world) //atoms (don't beleive its lies)
+			found_ref = DoSearchVar(thing, "World -> [thing.type]", search_time = starting_time) || found_ref
+		log_reftracker("Finished searching atoms")
+#else
+	for(var/datum/thing in world) //atoms (don't beleive its lies)
+		found_ref = DoSearchVar(thing, "World -> [thing.type]", search_time = starting_time) || found_ref
+	log_reftracker("Finished searching atoms")
+#endif
+	log_reftracker("Completed search for references to a [type]. [found_ref ? "Found reference(s)." : "No reference(s) found."]")
 
 	if(usr?.client)
 		usr.client.running_find_references = null
@@ -65,17 +74,18 @@
 	SSgarbage.next_fire = world.time + world.tick_lag
 
 /datum/proc/DoSearchVar(potential_container, container_name, recursive_limit = 64, search_time = world.time)
+	var/found_blocking_ref = FALSE
 	#ifdef REFERENCE_TRACKING_DEBUG
 	if(SSgarbage.should_save_refs && !found_refs)
 		found_refs = list()
 	#endif
 
 	if(usr?.client && !usr.client.running_find_references)
-		return
+		return found_blocking_ref
 
 	if(!recursive_limit)
 		log_reftracker("Recursion limit reached. [container_name]")
-		return
+		return found_blocking_ref
 
 	//Check each time you go down a layer. This makes it a bit slow, but it won't effect the rest of the game at all
 	#ifndef FIND_REF_NO_CHECK_TICK
@@ -85,11 +95,10 @@
 	if(istype(potential_container, /datum))
 		var/datum/datum_container = potential_container
 		if(datum_container.last_find_references == search_time)
-			return
+			return found_blocking_ref
 
 		datum_container.last_find_references = search_time
 		var/list/vars_list = datum_container.vars
-
 		for(var/varname in vars_list)
 			#ifndef FIND_REF_NO_CHECK_TICK
 			CHECK_TICK
@@ -104,6 +113,7 @@
 					found_refs[varname] = TRUE
 					continue //End early, don't want these logging
 				#endif
+				found_blocking_ref = TRUE
 				log_reftracker("Found [type] \ref[src] in [datum_container.type]'s \ref[datum_container] [varname] var. [container_name]")
 				continue
 
@@ -124,6 +134,7 @@
 					found_refs[potential_cache] = TRUE
 					continue //End early, don't want these logging
 				#endif
+				found_blocking_ref = TRUE
 				log_reftracker("Found [type] \ref[src] in list [container_name].")
 				continue
 
@@ -138,6 +149,7 @@
 					continue //End early, don't want these logging
 				#endif
 				log_reftracker("Found [type] \ref[src] in list [container_name]\[[element_in_list]\]")
+				found_blocking_ref = TRUE
 				continue
 			//We need to run both of these checks, since our object could be hiding in either of them
 			//Check normal sublists
@@ -146,6 +158,8 @@
 			//Check assoc sublists
 			if(islist(assoc_val))
 				DoSearchVar(potential_container[element_in_list], "[container_name]\[[element_in_list]\] -> [assoc_val] (list)", recursive_limit - 1, search_time)
+
+	return found_blocking_ref
 
 /proc/qdel_and_find_ref_if_fail(datum/thing_to_del, force = FALSE)
 	thing_to_del.qdel_and_find_ref_if_fail(force)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -47,10 +47,14 @@
 #include "check_adjustable_clothing.dm"
 #include "component_tests.dm"
 #include "connect_loc.dm"
-// Uncomment to enable Del the World.
+
+// Del the World.
 // This unit test creates and qdels almost every atom in the code, checking for errors with initialization and harddels on deletion.
-// It is disabled for now due to the large amount of consistent errors it produces.
-//#include "create_and_destroy.dm"
+// It is disabled by default for now due to the large amount of consistent errors it produces. Run the "dm: find hard deletes" task to enable it.
+#ifdef REFERENCE_TRACKING_FAST
+#include "create_and_destroy.dm"
+#endif
+
 #include "dynamic_ruleset_sanity.dm"
 #include "keybinding_init.dm"
 #include "reagent_id_typos.dm"


### PR DESCRIPTION
Adds `REFERENCE_TRACKING_FAST` which will only search for refs in `world.contents` if no other refs have been found.

Compare the timestamps of these two harddels. The first one needs to look in `world.contents`, the second one doesn't. The first takes ~2 minutes while the second takes ~8 seconds.
```
[2022-01-31 19:43:33.408] ## TESTING: GC: -- [0x2026111] | /obj/item/stock_parts/cell/emergency_light was unable to be GC'd --
[2022-01-31 19:44:01.962] ## REF SEARCH Beginning search for references to a /obj/item/stock_parts/cell/emergency_light.
[2022-01-31 19:44:02.151] ## REF SEARCH Finished searching globals
[2022-01-31 19:44:02.362] ## REF SEARCH Finished searching native globals
[2022-01-31 19:44:10.226] ## REF SEARCH Finished searching datums
[2022-01-31 19:44:10.228] ## REF SEARCH Finished searching clients
[2022-01-31 19:44:40.068] ## REF SEARCH Found /obj/item/stock_parts/cell/emergency_light [0x20260de] in /obj/machinery/light's [0x20260e3] cell var. World -> /obj/machinery/light
[2022-01-31 19:46:14.666] ## REF SEARCH Finished searching atoms
[2022-01-31 19:46:14.668] ## REF SEARCH Completed search for references to a /obj/item/stock_parts/cell/emergency_light. Found reference(s).
```
```
[2022-01-31 19:49:08.132] ## REF SEARCH Beginning search for references to a /datum/component/mood.
[2022-01-31 19:49:08.321] ## REF SEARCH Finished searching globals
[2022-01-31 19:49:08.535] ## REF SEARCH Finished searching native globals
[2022-01-31 19:49:13.410] ## REF SEARCH Found /datum/component/mood [0x2101f25c] in /datum/mood_event/jittery's [0x2101f250] owner var. Datums -> /datum/mood_event/jittery
[2022-01-31 19:49:16.428] ## REF SEARCH Finished searching datums
[2022-01-31 19:49:16.429] ## REF SEARCH Finished searching clients
[2022-01-31 19:49:16.431] ## REF SEARCH Skipped searching atoms (other ref(s) found)
[2022-01-31 19:49:16.432] ## REF SEARCH Completed search for references to a /datum/component/mood. Found reference(s).
```